### PR TITLE
Add CurlFile support for PHP 5.5+

### DIFF
--- a/models/Job/BeamscUpload.php
+++ b/models/Job/BeamscUpload.php
@@ -78,7 +78,7 @@ class Job_BeamscUpload extends Omeka_Job_AbstractJob
             // Title is the original filename because there is no file element 
             // when we save an item. File metadata can be updated later.
             'track[title]' => $file->original_filename,
-            'track[asset_data]' => '@' . FILES_DIR . '/original/' . $file->filename,
+            'track[asset_data]' => $this->_curlFile($file->filename),
             'track[sharing]' => ($_POST['BeamscShareOnSoundCloud'] == '1') ? 'public' : 'private',
         );
 
@@ -89,5 +89,24 @@ class Job_BeamscUpload extends Omeka_Job_AbstractJob
         }
 
         $track = json_decode($response);
+    }
+
+    /**
+     * Return appropriate curl file resource
+     *
+     * PHP 5.5 deprecated curl's '@filepath' notation in favor of a new CURLFile object.
+     * With PHP 5.6+ CURLFiles are required and '@filepath' notation is removed.
+     *
+     * @param string $filename the file name
+     * @return CURLFile|string
+     */
+    private function _curlFile($filename)
+    {
+        $file_path = FILES_DIR . '/original/' . $filename;
+        if (function_exists('curl_file_create')) {
+            return curl_file_create($file_path);
+        } else {
+            return '@' . $file_path;
+        }
     }
 }


### PR DESCRIPTION
This corrects a bug that causes SoundCloud to return 422 errors to hosts running PHP 5.6.

PHP 5.5 deprecated curl's '@filename' notation in favor of the [CURLFile](http://php.net/manual/en/class.curlfile.php) object, and PHP 5.6 removed '@filename' notation altogether. With '@filename' notation removed, requests sent from PHP 5.6 only included the file path as a string, not the file content.

This patch uses CURLFile if it's available and '@filename' if it isn't. 